### PR TITLE
Add client-side validation for entity types/info

### DIFF
--- a/assets/js/check-eligibility.js
+++ b/assets/js/check-eligibility.js
@@ -21,15 +21,61 @@
     return Object.fromEntries(formData);
   }
 
+  function isValidEntity({name, id}) {
+    const INVALID_ENTITY_TYPES = {
+      user_provided_organization_type: ["entity-none"],
+      met_spending_threshold: ["spend-no"],
+      is_usa_based: ["us-no"]
+    }
+
+    return !INVALID_ENTITY_TYPES[name].includes(id);
+  }
+
+  function resetErrorStates(el) {
+    const inputsWithErrors = Array.from(el.querySelectorAll('.usa-radio--error'));
+    inputsWithErrors.forEach(i => i.classList.remove('usa-radio--error'));
+  }
+
+  function validateEntity(entity) {
+    const radioEl = entity.parentElement;
+    const fieldsetEl = radioEl.parentElement;
+    resetErrorStates(fieldsetEl);
+
+    if (!isValidEntity(entity) && entity.checked) {
+      radioEl.classList.add('usa-radio--error');
+    };
+  }
+
+  function runAllValidations() {
+    const inputs = Array.from(document.querySelectorAll('.question input'));
+    const validations = [validateEntity];
+
+    inputs.forEach(input => {
+      validations.forEach(validation => validation(input));
+    })
+  }
+
+  function allResponsesValid() {
+    const inputsWithErrors = document.querySelectorAll('[class *="--error"]');
+    return inputsWithErrors.length === 0;
+  }
+
   function attachEventHandlers() {
     FORM.addEventListener('submit', (e) => {
       e.preventDefault();
+      if (!allResponsesValid()) return;
       submitForm();
     })
+
+    const questions = Array.from(document.querySelectorAll('.question'));
+    questions.forEach(q => {
+      q.addEventListener('change', e => validateEntity(e.target));
+    });
   }
 
   function init() {
     attachEventHandlers();
+    runAllValidations(); // Run these on load in case the user refreshed
   }
 
   init();

--- a/cypress/integration/check-eligibility.js
+++ b/cypress/integration/check-eligibility.js
@@ -22,4 +22,35 @@ describe('Create New Audit', () => {
       cy.focused().should('have.attr', 'type', 'radio');
     })
   })
+
+  describe('Validation', () => {
+    it('does not show any errors initially', () => {
+      cy.get('[class*=--error]').should('have.length', 0);
+    })
+
+    it('should mark errors when invalid properties are checked', () => {
+      // This needs to be a click on the label rather than a
+      // check on the input itself because of the CSS magic
+      // USWDS does to make the fancy radio buttons
+      cy.get('label[for=entity-none]').click();
+      cy.get('label[for=spend-no]').click();
+      cy.get('label[for=us-no]').click();
+      cy.get('[class*=--error]').should('have.length', 3);
+    })
+
+    it('should display error messages for invalid entities', () => {
+      cy.get('.usa-error-message:visible').should('have.length', 3);
+    })
+
+    it('should remove errors when valid properties are checked', () => {
+      cy.get('label[for=entity-state]').click();
+      cy.get('label[for=spend-yes]').click();
+      cy.get('label[for=us-yes]').click();
+      cy.get('[class*=--error]').should('have.length', 0);
+    })
+
+    it('should hide error messages when invalid entities are fixed', () => {
+      cy.get('.usa-error-message:visible').should('have.length', 0);
+    })
+  })
 })

--- a/src/_includes/components/usa-radio.njk
+++ b/src/_includes/components/usa-radio.njk
@@ -13,4 +13,7 @@
   <label class="usa-radio__label" for="{{ params.id }}">
     {{ params.label }}
   </label>
+  {%- if params.errorMessage -%}
+    <span class="usa-error-message">{{ params.errorMessage }}</span>
+  {%- endif -%}
 </div>

--- a/src/audit/new/index.njk
+++ b/src/audit/new/index.njk
@@ -24,9 +24,11 @@ fieldsets:
       - label: Unknown
         id: entity-unknown
         value: unknown
+        error_message: The FAC only accepts submissions from States, Local governments, Indian tribes or Tribal organizations, Institutions of higher education (IHEs), and Non-profits
       - label: None of the these (for example, for-profit)
         id: entity-none
         value: none
+        error_message: The FAC only accepts submissions from States, Local governments, Indian tribes or Tribal organizations, Institutions of higher education (IHEs), and Non-profits
 
   - group: met_spending_threshold
     legend: Did this entity spend $750,000 or more in federal awards during its audit period in accordance with Uniform Guidance?
@@ -38,6 +40,7 @@ fieldsets:
       - label: No
         id: spend-no
         value: false
+        error_message: The FAC only accepts submissions from non-Federal entities that spend $750,000 or more in federal awards during its audit period (fiscal period begin dates on or after 12/26/2014) in accordance with Uniform Guidance
 
   - group: is_usa_based
     legend: Is this entity U.S. based?
@@ -49,6 +52,7 @@ fieldsets:
       - label: No
         id: us-no
         value: false
+        error_message: The FAC only accepts submissions from U.S.-based entities
 ---
 {%- extends "form.njk" -%}
 {%- block form -%}
@@ -77,7 +81,8 @@ fieldsets:
               group: f.group,
               id: o.id,
               value: o.value,
-              required: true
+              required: true,
+              errorMessage: o.error_message
             })
           }}
         {% endfor %}

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -5,10 +5,6 @@
 .question {
   margin-bottom: 3rem;
 
-  &--error {
-    box-shadow: -5px 0 0 0 #b50909;
-  }
-
   .usa-legend {
     font-weight: 700;
   }

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -5,8 +5,28 @@
 .question {
   margin-bottom: 3rem;
 
+  &--error {
+    box-shadow: -5px 0 0 0 #b50909;
+  }
+
   .usa-legend {
     font-weight: 700;
+  }
+}
+
+.usa-radio .usa-error-message {
+  display: none;
+}
+
+.usa-radio--error {
+  .usa-error-message {
+    display: block;
+  }
+
+  .usa-radio__input:checked+[class*="__label"]::before {
+    background-color: #b50909;
+    box-shadow: 0 0 0 2px #b50909,
+                inset 0 0 0 2px #fff;
   }
 }
 


### PR DESCRIPTION
The existing FAC provides immediate feedback when a user enters info that would make them ineligible to submit. This PR adds similar functionality to the new frontend.

![image](https://user-images.githubusercontent.com/6290/164789483-62a48c78-96df-4a5b-bed8-66e02974f3fd.png)

[[View on Federalist](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh-validate-entities/audit/new/)]

Addresses GSA-TTS/FAC#122