### PR TITLE
Clarify "US-based" in eligibility criteria

### DIFF
--- a/src/audit/new/index.njk
+++ b/src/audit/new/index.njk
@@ -43,7 +43,7 @@ fieldsets:
         error_message: The FAC only accepts submissions from non-Federal entities that spend $750,000 or more in federal awards during its audit period (fiscal period begin dates on or after 12/26/2014) in accordance with Uniform Guidance
 
   - group: is_usa_based
-    legend: Is this entity U.S. based?
+    legend: Is this entity based in a US State, Territory, or Commonwealth?
     required: true
     options:
       - label: Yes


### PR DESCRIPTION
In light of the [conversation](https://github.com/GSA-TTS/FAC/issues/122#issuecomment-1117989591) in GSA-TTS/FAC#122, this PR updates question #3 of the eligibility screener to clarify what it means for an entity to be "US-based"

Old:
<img width="217" alt="image" src="https://user-images.githubusercontent.com/6290/168894878-a7fdb392-ccbe-40f3-a17f-804dd35721fb.png">

New:
<img width="509" alt="image" src="https://user-images.githubusercontent.com/6290/168894933-3cbf08d3-e2df-4516-adde-cceb9d5583c2.png">

👀 [Federalist preview](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh-eligibility-screener-tweaks/audit/new/)
