### PR TITLE
Display error when API call fails

### DIFF
--- a/cypress/integration/check-ueid.spec.js
+++ b/cypress/integration/check-ueid.spec.js
@@ -129,14 +129,34 @@ describe('Create New Audit', () => {
           'INTERNATIONAL BUSINESS MACHINES CORPORATION'
         );
       });
+
+      it('handles API errors', () => {
+        cy.intercept(
+          {
+            method: 'POST', // Route all GET requests
+            url: '/sac/ueivalidation', // that have a URL that matches '/users/*'
+          },
+          {
+            statusCode: 500,
+          }
+        ).as('apiError');
+
+        cy.get('button').contains('Validate UEI').click();
+
+        cy.wait('@apiError').then((interception) => {
+          assert.isNotNull(interception.response.body, '1st API call has data');
+        });
+
+        cy.get('#uei-error-message li').should('have.length', 1);
+      });
     });
   });
 
-  // describe('Accessibility', () => {
-  //   it('should get a perfect Lighthouse score for accessibility', () => {
-  //     cy.lighthouse({
-  //       accessibility: 100,
-  //     });
-  //   });
-  // });
+  describe('Accessibility', () => {
+    it('should get a perfect Lighthouse score for accessibility', () => {
+      cy.lighthouse({
+        accessibility: 100,
+      });
+    });
+  });
 });

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -42,8 +42,10 @@ function handleInvalidUei(errors) {
   errorContainer.hidden = false;
 }
 
-function handleApiError(error) {
-  console.error(error);
+function handleApiError() {
+  const errorMsg = `We can’t connect to SAM.gov to confirm your UEI. We're sorry for the delay. You can continue, but we'll need to confirm your UEI before your audit can be certified.`;
+
+  handleInvalidUei({ uei: [errorMsg] });
 }
 
 function validateUEID() {


### PR DESCRIPTION
Per the discussion in GSA-TTS/FAC#126, this PR adds an error message that displays when there is an error in the response from the API.

<img width="462" alt="image" src="https://user-images.githubusercontent.com/6290/169108573-94a39145-d340-4f4c-b86e-b11298d2cbea.png">

👀 [Federalist preview](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh-display-api-error-126/audit/new/step-2/)

The Cypress spec does verify this behavior, but an enterprising tester can verify the failure state by [disabling requests to the API in Chrome's devtools](https://dandkim.com/debugging-block-network-request/).