### PR TITLE
Implement adding additional contact fields

### DIFF
--- a/cypress/integration/check-access.spec.js
+++ b/cypress/integration/check-access.spec.js
@@ -322,6 +322,13 @@ describe('Create New Audit', () => {
           );
         });
       });
+
+      it('should allow adding new contact fields', () => {
+        cy.get('.auditee_contacts').within(() => {
+          cy.get('button').click();
+          cy.get('.grid-row').should('have.length', 2);
+        });
+      });
     });
 
     describe('Auditor contacts', () => {
@@ -407,6 +414,13 @@ describe('Create New Audit', () => {
           cy.get('#auditor_contacts_re_email-must-match').should(
             'not.be.visible'
           );
+        });
+      });
+
+      it('should allow adding new contact fields', () => {
+        cy.get('.auditor_contacts').within(() => {
+          cy.get('button').click();
+          cy.get('.grid-row').should('have.length', 2);
         });
       });
     });

--- a/src/audit/new/step-3/index.njk
+++ b/src/audit/new/step-3/index.njk
@@ -110,7 +110,7 @@ email_notice: The above contacts will receive an e-mail once this audit is creat
         {% for f in dynamic_fieldsets %}
         <fieldset class="usa-fieldset question" aria-labelledby="{{ f.group }}_legend dynamic_fieldset_instruction">
           <legend id="{{ f.group }}_legend" class="usa-legend">{{ f.legend }}</legend>
-          <div class="grid-container">
+          <div class="grid-container {{ f.group }}">
             <div class="grid-row grid-gap">
               {% for i in inputs %}
               {% set validations = [{
@@ -131,9 +131,28 @@ email_notice: The above contacts will receive an e-mail once this audit is creat
                 </div>
               {% endfor %}
             </div>
-            <p>
-              <a class="usa-link" href="javascript:void(0);">Add another contact</a>
-            </p>
+            <template id="{{ f.group }}-template">
+              <div class="grid-row grid-gap">
+                {% for i in inputs %}
+                {% set validations = [{
+                  "operation": "must-match",
+                  "constraint": f.group + "_email",
+                  "error_message": "This field should match the one before it"
+                }] if i.id === "_re_email" else i.validations %}
+                  <div class="tablet:grid-col-fill">
+                    {{
+                      component('usa-input', {
+                        label: i.label,
+                        id: f.group + i.id,
+                        required: i.required,
+                        errorMessage: i.error_message,
+                        validations: validations
+                    })
+                  }}
+                  </div>
+                {% endfor %}
+              </template>
+              <button class="usa-button usa-button--unstyled add-contact" href="javascript:void(0);">Add another contact</button>
           </div>
         </fieldset>
         {% endfor %}

--- a/src/js/check-access.js
+++ b/src/js/check-access.js
@@ -17,6 +17,13 @@ function performValidations(field) {
   setFormDisabled(errors.length > 0);
 }
 
+function appendContactField(btnEl) {
+  const inputContainer = btnEl.parentElement;
+  const template = inputContainer.querySelector('template');
+  const newRow = template.content.cloneNode(true);
+  inputContainer.insertBefore(newRow, template);
+}
+
 function attachEventHandlers() {
   FORM.addEventListener('submit', (e) => {
     e.preventDefault();
@@ -30,6 +37,16 @@ function attachEventHandlers() {
   fieldsNeedingValidation.forEach((q) => {
     q.addEventListener('blur', (e) => {
       performValidations(e.target);
+    });
+  });
+
+  const addContactButtons = Array.from(
+    document.querySelectorAll('.add-contact')
+  );
+  addContactButtons.forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      appendContactField(e.target);
     });
   });
 }


### PR DESCRIPTION
This PR adds the ability to create additional contacts for auditees and auditors, as described in GSA-TTS/FAC#200.

![chrome-capture-2022-4-23](https://user-images.githubusercontent.com/6290/169884642-e05f5319-3556-4a4b-b33f-a3ddddf1426c.gif)

👀 [Federalist preview](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh-audit-submission-access-refinements/audit/new/step-3/)
