### PR TITLE
Support deleting additional contact fields

### DIFF
--- a/cypress/integration/check-access.spec.js
+++ b/cypress/integration/check-access.spec.js
@@ -329,6 +329,11 @@ describe('Create New Audit', () => {
           cy.get('.grid-row').should('have.length', 2);
         });
       });
+
+      it('should allow deleting additional contact fields', () => {
+        cy.get('.auditee_contacts .delete-contact').click();
+        cy.get('.auditee_contacts .grid-row').should('have.length', 1);
+      });
     });
 
     describe('Auditor contacts', () => {
@@ -422,6 +427,11 @@ describe('Create New Audit', () => {
           cy.get('button').click();
           cy.get('.grid-row').should('have.length', 2);
         });
+      });
+
+      it('should allow deleting additional contact fields', () => {
+        cy.get('.auditor_contacts .delete-contact').click();
+        cy.get('.auditor_contacts .grid-row').should('have.length', 1);
       });
     });
   });

--- a/src/audit/new/step-3/index.njk
+++ b/src/audit/new/step-3/index.njk
@@ -151,8 +151,13 @@ email_notice: The above contacts will receive an e-mail once this audit is creat
                   }}
                   </div>
                 {% endfor %}
+                <button class="usa-button usa-button--unstyled delete-contact" aria-label="Delete contact" title="Delete contact">
+                  <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+                    <use xlink:href="{{ config.baseUrl }}assets/img/sprite.svg#cancel"></use>
+                  </svg>
+                </button>
               </template>
-              <button class="usa-button usa-button--unstyled add-contact" href="javascript:void(0);">Add another contact</button>
+              <button class="usa-button usa-button--unstyled add-contact">Add another contact</button>
           </div>
         </fieldset>
         {% endfor %}

--- a/src/js/check-access.js
+++ b/src/js/check-access.js
@@ -22,6 +22,26 @@ function appendContactField(btnEl) {
   const template = inputContainer.querySelector('template');
   const newRow = template.content.cloneNode(true);
   inputContainer.insertBefore(newRow, template);
+  const deleteBtns = Array.from(document.querySelectorAll('.delete-contact'));
+
+  deleteBtns.forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      deleteContactField(e.target);
+    });
+  });
+}
+
+function deleteContactField(el) {
+  const nodeName = el.nodeName;
+  const inputContainer =
+    nodeName == 'use'
+      ? el.parentElement.parentElement.parentElement
+      : nodeName == 'svg'
+      ? el.parentElement.parentElement
+      : el.parentElement;
+
+  inputContainer.remove();
 }
 
 function attachEventHandlers() {

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -99,6 +99,19 @@ a.usa-button {
   }
 }
 
+.delete-contact {
+  margin: 0 !important;
+  margin-top: auto !important;
+  margin-bottom: .5rem !important;
+  padding: 0 !important;
+
+  .usa-icon {
+    fill: #d83933;
+    height: 1.5em;
+    width: 1.5em;
+  }
+}
+
 /* stylelint-disable */
 #auditee_name {
   cursor: not-allowed;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,4 +1,4 @@
-@use 'uswds-core' with($theme-show-notifications: false,
+@use 'uswds-core' as * with($theme-show-notifications: false,
   $theme-font-path: '../../assets/fonts',
   $theme-image-path: '../../assets/img'
 );


### PR DESCRIPTION
Once a user adds more contact fields, they should be able to delete them too. This PR implements that.

![chrome-capture-2022-4-26](https://user-images.githubusercontent.com/6290/170554055-db389f61-a195-491d-a205-7d003efe3ff4.gif)

👀 [Federalist preview](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh-delete-new-contact-rows-200/audit/new/step-3/)