### PR TITLE
Update `lint-staged` script names

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-  "*.js": ["npm run eslint:fix"],
-  "*.scss": ["npm run stylelint:fix"]
+  "*.js": ["npm run fix:eslint"],
+  "*.scss": ["npm run fix:stylelint"]
 }


### PR DESCRIPTION
I renamed some of the package scripts in 244f48c but neglected to update the pre-commit hook to reflect those changes. This PR fixes that. 