### PR TITLE
Ensure FY began after 12/31/2019

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-  "*.js": ["npm run eslint:fix"],
-  "*.scss": ["npm run stylelint:fix"]
+  "*.js": ["npm run fix:eslint"],
+  "*.scss": ["npm run fix:stylelint"]
 }

--- a/cypress/integration/check-ueid.spec.js
+++ b/cypress/integration/check-ueid.spec.js
@@ -150,6 +150,18 @@ describe('Create New Audit', () => {
         cy.get('#uei-error-message li').should('have.length', 1);
       });
     });
+
+    describe('Fiscal Year Validation', () => {
+      it('should show an error if the user enters a date before 1/1/2020', () => {
+        cy.get('#auditee_fy_start_date_start').type('12/31/2019');
+        cy.get('#fy-error-message li').should('have.length', 1);
+      });
+
+      it('should not show an error if the user enters a date after 12/31/2019', () => {
+        cy.get('#auditee_fy_start_date_start').clear().type('12/31/2020');
+        cy.get('#fy-error-message li').should('have.length', 0);
+      });
+    });
   });
 
   describe('Accessibility', () => {

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -110,12 +110,14 @@ explanatory_text:
           </div>
           {% elif i.field_type == "date" %}
           <div class="usa-form-group validate-fy">
+            {% if i.id == "auditee_fy_start_date_start" %}
             <ul class="usa-error-message"
               id="fy-error-message"
               role="alert"
               tabindex="-1"
               >
             </ul>
+            {% endif %}
             {{
               component('usa-date-picker', {
                 label: i.label,

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -69,7 +69,7 @@ explanatory_text:
 </div>
 <div class="grid-container auditee-information">
   <div class="grid-row">
-    <form class="usa-form usa-form--large tablet:grid-col" id="check-eligibility">
+    <form class="usa-form usa-form--large tablet:grid-col" id="check-eligibility" data-fy-end-date="">
       <fieldset class="usa-fieldset">
         <legend class="usa-legend usa-legend--large">Auditee information</legend>
         <p>
@@ -109,6 +109,13 @@ explanatory_text:
             </button>
           </div>
           {% elif i.field_type == "date" %}
+          <div class="usa-form-group validate-fy">
+            <ul class="usa-error-message"
+              id="fy-error-message"
+              role="alert"
+              tabindex="-1"
+              >
+            </ul>
             {{
               component('usa-date-picker', {
                 label: i.label,
@@ -117,6 +124,7 @@ explanatory_text:
                 errorMessage: i.error_message
               })
             }}
+          </div>
           {% endif %}
         {% endfor %}
         </fieldset>

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -12,7 +12,6 @@ function submitForm() {
 
 function handleUEIDResponse({ valid, response, errors }) {
   if (valid) {
-    recordFYEndDate(response.auditee_fiscal_year_end_date);
     handleValidUei(response.auditee_name);
   } else {
     handleInvalidUei(errors);
@@ -63,27 +62,29 @@ function validateUEID() {
   );
 }
 
-function recordFYEndDate(fyEndDate) {
-  FORM.dataset.fyEndDate = fyEndDate;
-}
-
-function validateFyEndDate(fyInput) {
-  const samFy = FORM.dataset.fyEndDate;
+function validateFyStartDate(fyInput) {
   if (fyInput.value == '') return;
 
   const fyFormGroup = document.querySelector('.usa-form-group.validate-fy');
   const fyErrorContainer = document.getElementById('fy-error-message');
   const userFy = {};
   [userFy.year, userFy.month, userFy.day] = fyInput.value.split('-');
-  [samFy.month, samFy.day] = samFy.split('/');
 
-  if (userFy.year < 2022) {
+  if (userFy.year < 2020) {
     const errorEl = document.createElement('li');
-    errorEl.innerText = 'We are currently only accepting audits from FY22';
+    errorEl.innerHTML =
+      'We are currently only accepting audits from FY22.\
+      To submit an audit for a different fiscal period, \
+      visit the <a href="https://facides.census.gov/Account/Login.aspx">Census Bureau</a>.';
     fyErrorContainer.appendChild(errorEl);
     fyFormGroup.classList.add('usa-form-group--error');
     fyErrorContainer.focus();
+  } else {
+    fyFormGroup.classList.remove('usa-form-group--error');
+    fyErrorContainer.innerHTML = '';
   }
+
+  setFormDisabled(!allResponsesValid());
 }
 
 /*
@@ -103,7 +104,7 @@ function setFormDisabled(shouldDisable) {
 
 function allResponsesValid() {
   const inputsWithErrors = document.querySelectorAll('[class *="--error"]');
-  return inputsWithErrors.length === 0;
+  return inputsWithErrors.length == 0;
 }
 
 function performValidations(field) {
@@ -133,9 +134,9 @@ function attachEventHandlers() {
     });
   });
 
-  const fyInput = document.getElementById('auditee_fy_start_date_end');
+  const fyInput = document.getElementById('auditee_fy_start_date_start');
   fyInput.addEventListener('change', (e) => {
-    validateFyEndDate(e.target);
+    validateFyStartDate(e.target);
   });
 }
 

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -12,6 +12,7 @@ function submitForm() {
 
 function handleUEIDResponse({ valid, response, errors }) {
   if (valid) {
+    recordFYEndDate(response.auditee_fiscal_year_end_date);
     handleValidUei(response.auditee_name);
   } else {
     handleInvalidUei(errors);
@@ -62,6 +63,29 @@ function validateUEID() {
   );
 }
 
+function recordFYEndDate(fyEndDate) {
+  FORM.dataset.fyEndDate = fyEndDate;
+}
+
+function validateFyEndDate(fyInput) {
+  const samFy = FORM.dataset.fyEndDate;
+  if (fyInput.value == '') return;
+
+  const fyFormGroup = document.querySelector('.usa-form-group.validate-fy');
+  const fyErrorContainer = document.getElementById('fy-error-message');
+  const userFy = {};
+  [userFy.year, userFy.month, userFy.day] = fyInput.value.split('-');
+  [samFy.month, samFy.day] = samFy.split('/');
+
+  if (userFy.year < 2022) {
+    const errorEl = document.createElement('li');
+    errorEl.innerText = 'We are currently only accepting audits from FY22';
+    fyErrorContainer.appendChild(errorEl);
+    fyFormGroup.classList.add('usa-form-group--error');
+    fyErrorContainer.focus();
+  }
+}
+
 /*
 We're not submitting this form yet,
 so this won't be called. Rather than delete code we know we need,
@@ -107,6 +131,11 @@ function attachEventHandlers() {
     q.addEventListener('blur', (e) => {
       performValidations(e.target);
     });
+  });
+
+  const fyInput = document.getElementById('auditee_fy_start_date_end');
+  fyInput.addEventListener('change', (e) => {
+    validateFyEndDate(e.target);
   });
 }
 


### PR DESCRIPTION
This PR adds validation to the entity's FY start date. By the reasoning in this [comment](https://github.com/GSA-TTS/FAC/issues/127#issuecomment-1129099541), if the provided FY begins before 1/1/2020, we know it's not possible for the submission to be for FY22, so we display an error directing the user to the legacy FAC.

![chrome-capture-2022-4-27](https://user-images.githubusercontent.com/6290/170736537-726c0f2f-10cb-4de5-a346-de8ef488a27b.gif)

👀 [Federalist preview](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh-validate-fy-date-127/audit/new/step-2/)