### PR TITLE
Wire up homepage login button, update post-login redirect

### DIFF
--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -3,7 +3,7 @@
       <h1 class="usa-hero__heading">{{ hero.callout.text }}</h1>
       <p>{{ hero.content | safe }}</p>
       <div class="usa-button-group">
-        <a class="usa-button" href="{{ hero.buttons.primary.href }}">
+        <a class="usa-button sign-in-button" href="{{ hero.buttons.primary.href }}">
           {{ hero.buttons.primary.text }}
         </a>
         <a class="usa-button usa-button--outline" href="{{ hero.buttons.secondary.href }}">

--- a/src/_includes/components/usa-modal.njk
+++ b/src/_includes/components/usa-modal.njk
@@ -15,7 +15,7 @@
       <div class="usa-modal__footer">
         <ul class="usa-button-group">
           <li class="usa-button-group__item">
-            <button type="button" class="usa-button" id="{{ params.continueButton.id }}" data-close-modal>
+            <button type="button" class="usa-button {{ params.continueButton.class }}" id="{{ params.continueButton.id }}" data-close-modal>
               {{ params.continueButton.text }} 
             </button>
           </li>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -64,7 +64,8 @@
             heading: 'Submitting information to the Federal Audit Clearinghouse requires authentication',
             continueButton: {
               text: 'Authenticate with Login.gov',
-              id: 'sign-in'
+              id: 'sign-in',
+              class: 'sign-in-button'
             },
             backButtonText: 'Go back',
             description: '<p>General Services Administration Notice and Consent Warning</p>

--- a/src/index.md
+++ b/src/index.md
@@ -8,7 +8,7 @@ hero:
   content: The FAC is transitioning to the General Services Administration to help the public  in oversight, transparency and assessment of Federal award audit requirements. Only audits from 2021 will be searchable on this site until we migrate systems, so please use the <a href="https://facides.census.gov/Account/Login.aspx">legacy FAC IMS</a> to search older records.
   buttons:
     primary:
-      href: /callout/
+      href: /#
       text: Log in to submit an audit
     secondary:
       href: /callout/

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -30,8 +30,8 @@ export const getApiToken = () => {
 
 (function () {
   function attachSignInButtonHandler() {
-    const signInButton = document.getElementById('sign-in');
-    if (signInButton) {
+    const signInButtons = document.getElementsByClassName('sign-in-button');
+    Array.prototype.forEach.call(signInButtons, (signInButton) => {
       signInButton.addEventListener('click', () => {
         const nonce = crypto.lib.WordArray.random(32).toString(
           crypto.enc.Base64
@@ -44,7 +44,7 @@ export const getApiToken = () => {
           nonce,
         });
       });
-    }
+    });
   }
 
   function attachEventHandlers() {
@@ -66,7 +66,7 @@ export const getApiToken = () => {
         })
           .then((resp) => resp.json())
           .then((data) => tokenStore.set('fac-api-token', data.token))
-          .then(() => (window.location = appBaseUrl));
+          .then(() => (window.location = appBaseUrl + 'audit/new/step-1'));
       });
     }
   }


### PR DESCRIPTION
Resolves [#135](https://github.com/GSA-TTS/FAC/issues/135)

- Makes the "Log in to submit an audit" button on the homepage functional
- Updates the post-login landing location to `/audit/new/step-1`