### PR TITLE
Implement new UEI lookup flow

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -12,6 +12,6 @@
       "htmlcs",
       "axe"
     ],
-    "hideElements": ".usa-select, .usa-step-indicator__segment-label"
+    "hideElements": ".usa-select, .usa-step-indicator__segment-label, .is-hidden"
   }
 }

--- a/cypress/integration/check-ueid-submit.spec.js
+++ b/cypress/integration/check-ueid-submit.spec.js
@@ -8,10 +8,9 @@ describe('Create New Audit', () => {
       cy.get('[class*=--error]').should('have.length', 0);
     });
 
-    describe('ADD Auditee UEID', () => {
-      it('should add auditee UEID and confirm auditee UEID', () => {
+    describe('Add Auditee UEID', () => {
+      it('should add auditee UEI', () => {
         cy.get('#auditee_uei').clear().type('ZQGGHJH74DW7').blur();
-        cy.get('#confirm_auditee_uei').clear().type('ZQGGHJH74DW7').blur();
       });
     });
 
@@ -31,11 +30,13 @@ describe('Create New Audit', () => {
           }
         ).as('validUeiRequest');
 
-        cy.get('button').contains('Validate UEI').click();
+        cy.get('#auditee_uei-btn').click();
 
         cy.wait('@validUeiRequest').then((interception) => {
           assert.isNotNull(interception.response.body, '1st API call has data');
         });
+
+        cy.get('.usa-modal__footer button.primary').as('primaryButton').click();
 
         cy.get('#uei-error-message li').should('have.length', 0);
         cy.get('#auditee_name').should(

--- a/cypress/integration/check-ueid.spec.js
+++ b/cypress/integration/check-ueid.spec.js
@@ -72,7 +72,6 @@ describe('Create New Audit', () => {
     describe('UEI Validation via API', () => {
       beforeEach(() => {
         cy.get('#auditee_uei-btn').as('searchButton');
-        cy.get('.usa-modal__close').as('closeModalButton');
         cy.get('.usa-modal__footer button.primary').as('primaryButton');
         cy.get('.usa-modal__footer button.secondary').as('secondaryButton');
       });

--- a/cypress/integration/check-ueid.spec.js
+++ b/cypress/integration/check-ueid.spec.js
@@ -5,7 +5,7 @@ describe('Create New Audit', () => {
 
   describe('A Blank Form', () => {
     it('marks empty responses as invalid', () => {
-      cy.get('.auditee-information input:invalid').should('have.length', 2);
+      cy.get('.auditee-information input:invalid').should('have.length', 1);
     });
 
     it('will not submit', () => {
@@ -21,12 +21,6 @@ describe('Create New Audit', () => {
   describe('Validation', () => {
     it('does not show any errors initially', () => {
       cy.get('[class*=--error]').should('have.length', 0);
-    });
-
-    it('should mark errors when invalid properties are checked', () => {
-      cy.get('#auditee_uei').click().blur();
-      cy.get('#confirm_auditee_uei').click().blur();
-      cy.get('[class*=usa-form-group--error]').should('have.length', 2);
     });
 
     describe('Auditee UEID', () => {
@@ -63,97 +57,6 @@ describe('Create New Audit', () => {
       });
     });
 
-    describe('Auditee UEID Confirmation', () => {
-      it('should display an error message when input does not match UEID field', () => {
-        cy.get('#confirm_auditee_uei').type('ASDF').blur();
-        cy.get('#confirm_auditee_uei-must-match').should('be.visible');
-      });
-
-      it('should remove the error message when input matches UEID field', () => {
-        cy.get('#confirm_auditee_uei').type('ASDFASDF').blur();
-        cy.get('#confirm_auditee_uei-must-match').should('not.be.visible');
-      });
-      it('should enable the "Continue" button when entities are fixed', () => {
-        cy.get('button').contains('Continue').should('not.be.disabled');
-      });
-    });
-
-    describe('UEI Validation via API', () => {
-      it('handles API errors', () => {
-        cy.intercept(
-          {
-            method: 'POST', // Route all GET requests
-            url: '/sac/ueivalidation', // that have a URL that matches '/users/*'
-          },
-          {
-            statusCode: 500,
-          }
-        ).as('apiError');
-
-        cy.get('button').contains('Validate UEI').click();
-
-        cy.wait('@apiError').then((interception) => {
-          assert.isNotNull(interception.response.body, '1st API call has data');
-        });
-
-        cy.get('#uei-error-message li').should('have.length', 1);
-      });
-
-      it('shows UEI errors from the remote server', () => {
-        cy.intercept(
-          {
-            method: 'POST',
-            url: '/sac/ueivalidation',
-          },
-          {
-            valid: false,
-            errors: {
-              uei: [
-                'The letters “O” and “I” are not used to avoid confusion with zero and one.',
-                'Ensure this field has at least 12 characters.',
-              ],
-            },
-          }
-        ).as('invalidUeiRequest');
-
-        cy.get('button').contains('Validate UEI').click();
-
-        cy.wait('@invalidUeiRequest').then((interception) => {
-          assert.isNotNull(interception.response.body, '1st API call has data');
-        });
-
-        cy.get('#uei-error-message li').should('have.length', 3);
-      });
-
-      it('shows entity name after valid UEI request', () => {
-        cy.intercept(
-          {
-            method: 'POST', // Route all GET requests
-            url: '/sac/ueivalidation', // that have a URL that matches '/users/*'
-          },
-          {
-            valid: true,
-            response: {
-              uei: 'ZQGGHJH74DW7',
-              auditee_name: 'INTERNATIONAL BUSINESS MACHINES CORPORATION',
-            },
-          }
-        ).as('validUeiRequest');
-
-        cy.get('button').contains('Validate UEI').click();
-
-        cy.wait('@validUeiRequest').then((interception) => {
-          assert.isNotNull(interception.response.body, '1st API call has data');
-        });
-
-        cy.get('#uei-error-message li').should('have.length', 0);
-        cy.get('#auditee_name').should(
-          'have.value',
-          'INTERNATIONAL BUSINESS MACHINES CORPORATION'
-        );
-      });
-    });
-
     describe('Fiscal Year Validation', () => {
       it('should show an error if the user enters a date before 1/1/2020', () => {
         cy.get('#auditee_fiscal_period_start').type('12/31/2019');
@@ -163,6 +66,159 @@ describe('Create New Audit', () => {
       it('should not show an error if the user enters a date after 12/31/2019', () => {
         cy.get('#auditee_fiscal_period_start').clear().type('12/31/2020');
         cy.get('#fy-error-message li').should('have.length', 0);
+      });
+    });
+
+    describe('UEI Validation via API', () => {
+      beforeEach(() => {
+        cy.get('#auditee_uei-btn').as('searchButton');
+        cy.get('.usa-modal__close').as('closeModalButton');
+        cy.get('.usa-modal__footer button.primary').as('primaryButton');
+        cy.get('.usa-modal__footer button.secondary').as('secondaryButton');
+      });
+
+      afterEach(() => {
+        cy.reload();
+      });
+
+      describe('Connection Errors', () => {
+        beforeEach(() => {
+          cy.intercept(
+            {
+              method: 'POST', // Route all GET requests
+              url: '/sac/ueivalidation', // that have a URL that matches '/users/*'
+            },
+            {
+              statusCode: 500,
+            }
+          ).as('apiError');
+        });
+
+        it('handles API errors', () => {
+          cy.get('@searchButton').click();
+
+          cy.wait('@apiError').then((interception) => {
+            assert.isNotNull(
+              interception.response.body,
+              '1st API call has data'
+            );
+          });
+
+          cy.contains(`We can't connect to SAM.gov to confirm your UEI.`);
+        });
+
+        it('lets the user proceed without a UEI', () => {
+          cy.get('@searchButton').click();
+
+          cy.wait('@apiError').then((interception) => {
+            assert.isNotNull(
+              interception.response.body,
+              '1st API call has data'
+            );
+          });
+
+          cy.get('@secondaryButton').click();
+          cy.get('#no-uei-warning').should('be.visible');
+          cy.get('#auditee_uei').should('not.be.visible');
+        });
+      });
+
+      describe('An invalid UEI', () => {
+        beforeEach(() => {
+          cy.intercept(
+            {
+              method: 'POST',
+              url: '/sac/ueivalidation',
+            },
+            {
+              valid: false,
+              errors: {
+                auditee_uei: [
+                  'The letters “O” and “I” are not used to avoid confusion with zero and one.',
+                  'Ensure this field has at least 12 characters.',
+                ],
+              },
+            }
+          ).as('invalidUeiRequest');
+        });
+
+        it('Lets users know when their UEI is not recognized', () => {
+          cy.get('@searchButton').click();
+
+          cy.wait('@invalidUeiRequest').then((interception) => {
+            assert.isNotNull(
+              interception.response.body,
+              '1st API call has data'
+            );
+          });
+
+          cy.contains('Your UEI is not recognized');
+        });
+
+        it('lets the user proceed without a UEI', () => {
+          cy.get('@searchButton').click();
+
+          cy.wait('@invalidUeiRequest').then((interception) => {
+            assert.isNotNull(
+              interception.response.body,
+              '1st API call has data'
+            );
+          });
+
+          cy.get('@primaryButton').click();
+          cy.get('#no-uei-warning').should('be.visible');
+          cy.get('#auditee_uei').should('not.be.visible');
+        });
+      });
+
+      describe('A successful lookup', () => {
+        beforeEach(() => {
+          cy.intercept(
+            {
+              method: 'POST', // Route all GET requests
+              url: '/sac/ueivalidation', // that have a URL that matches '/users/*'
+            },
+            {
+              valid: true,
+              response: {
+                uei: 'ZQGGHJH74DW7',
+                auditee_name: 'INTERNATIONAL BUSINESS MACHINES CORPORATION',
+              },
+            }
+          ).as('validUeiRequest');
+        });
+
+        it('shows entity name after valid UEI request', () => {
+          cy.get('@searchButton').click();
+
+          cy.wait('@validUeiRequest').then((interception) => {
+            assert.isNotNull(
+              interception.response.body,
+              '1st API call has data'
+            );
+          });
+
+          cy.get('#uei-error-message li').should('have.length', 0);
+          cy.get('#auditee_name').should(
+            'have.value',
+            'INTERNATIONAL BUSINESS MACHINES CORPORATION'
+          );
+        });
+
+        it('Shows UEI and name in the page and hides the search field', () => {
+          cy.get('@searchButton').click();
+
+          cy.wait('@validUeiRequest').then((interception) => {
+            assert.isNotNull(
+              interception.response.body,
+              '1st API call has data'
+            );
+          });
+
+          cy.get('@primaryButton').click();
+          cy.get('#auditee_uei').should('not.be.visible');
+          cy.get('[data-testid=uei-info]').should('be.visible');
+        });
       });
     });
   });

--- a/src/_includes/components/usa-search.njk
+++ b/src/_includes/components/usa-search.njk
@@ -20,6 +20,7 @@
     id="{{ params.id }}"
     type="search"
     name="search"
+    {{ 'required' if params.required }}
     {% for v in params.validations %}
       data-validate-{{v.operation}}="{{v.constraint}}"
     {% endfor %}

--- a/src/_includes/components/usa-search.njk
+++ b/src/_includes/components/usa-search.njk
@@ -1,5 +1,5 @@
-<div class="usa-search usa-form-group" role="search">
-  <label class="usa-sr-only" for="{{ params.id }}">Search</label>
+<div class="usa-form-group">
+
   <ul class="usa-error-message"
     id="{{ params.id }}-error-message"
     role="alert"
@@ -13,7 +13,17 @@
       </li>
     {% endfor %}
   </ul>
-  <input class="usa-input" id="{{ params.id }}" type="search" name="search" />
+<div class="usa-search" role="search">
+  <label class="usa-sr-only" for="{{ params.id }}">Search</label>
+  <input
+    class="usa-input"
+    id="{{ params.id }}"
+    type="search"
+    name="search"
+    {% for v in params.validations %}
+      data-validate-{{v.operation}}="{{v.constraint}}"
+    {% endfor %}
+    />
   <button
     class="usa-button"
     id="{{ params.id }}-btn"
@@ -32,4 +42,6 @@
       Search
     </span>
   </button>
+</div>
+
 </div>

--- a/src/_includes/components/usa-search.njk
+++ b/src/_includes/components/usa-search.njk
@@ -1,4 +1,4 @@
-<div class="usa-search" role="search">
+<div class="usa-search usa-form-group" role="search">
   <label class="usa-sr-only" for="{{ params.id }}">Search</label>
   <ul class="usa-error-message"
     id="{{ params.id }}-error-message"

--- a/src/_includes/components/usa-search.njk
+++ b/src/_includes/components/usa-search.njk
@@ -1,0 +1,27 @@
+<div class="usa-search" role="search">
+  <label class="usa-sr-only" for="{{ params.id }}">Search</label>
+  <ul class="usa-error-message"
+    id="{{ params.id }}-error-message"
+    role="alert"
+    >
+    {% for v in params.validations %}
+      <li
+        id="{{ params.id }}-{{ v.operation }}"
+        hidden
+        >
+        {{ v.error_message }}
+      </li>
+    {% endfor %}
+  </ul>
+  <input class="usa-input" id="{{ params.id }}" type="search" name="search" />
+  <button class="usa-button" id="{{ params.id }}-btn" type="submit">
+    <span class="usa-search__submit-text">
+      <img
+        src="{{ params.baseUrl }}assets/img/usa-icons-bg/search--white.svg"
+        class="usa-search__submit-icon"
+        alt="Search"
+      />
+      Search
+    </span>
+  </button>
+</div>

--- a/src/_includes/components/usa-search.njk
+++ b/src/_includes/components/usa-search.njk
@@ -14,7 +14,15 @@
     {% endfor %}
   </ul>
   <input class="usa-input" id="{{ params.id }}" type="search" name="search" />
-  <button class="usa-button" id="{{ params.id }}-btn" type="submit">
+  <button
+    class="usa-button"
+    id="{{ params.id }}-btn"
+    type="submit"
+    {% if params.controlsModal %}
+      aria-controls={{ params.controlsModal }}
+      data-open-modal
+    {% endif %}
+    >
     <span class="usa-search__submit-text">
       <img
         src="{{ params.baseUrl }}assets/img/usa-icons-bg/search--white.svg"

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -1,7 +1,7 @@
 ---
 title: Create new audit
 
-uei-search:
+uei_search:
     validations:
       - operation: not-null
         error_message: Can't be null
@@ -89,7 +89,7 @@ explanatory_text:
             component('usa-search', {
               id: 'auditee_uei',
               baseUrl: config.baseUrl,
-              validations: uei-search.validations,
+              validations: uei_search.validations,
               controlsModal: 'uei-search-result'
             })
           }}

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -40,7 +40,7 @@ inputs:
     label: Auditee name
     disabled: true
     field_type: text
-    error_message: Auditee Name cannot be blank
+    error_message: Auditee Name is required if proceeding without a valid UEI
 
   - id: auditee_fiscal_period_start
     label: Auditee fiscal period <strong>start</strong> date for this submission
@@ -84,7 +84,18 @@ explanatory_text:
           >Indicates a required field.
         </p>
 
-          <p>Search by Unique Entity Identifier (UEI) for your entity name in the SAM.gov database.</p>
+        <div id="no-uei-warning" hidden>
+          <h2>
+            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+              <use xlink:href="{{config.baseUrl}}assets/img/sprite.svg#error_outline"></use>
+            </svg>
+            Your UEI was not confirmed
+          </h2>
+            <p>You  can continue, but you will have to confirm your UEI before you’re submission can be certified.
+  You will be able to update the UEI later on.</p>
+        </div>
+
+          <p class="uei-explanation">Search by Unique Entity Identifier (UEI) for your entity name in the SAM.gov database.</p>
           {{
             component('usa-search', {
               id: 'auditee_uei',
@@ -94,7 +105,7 @@ explanatory_text:
             })
           }}
 
-          <p>Don’t know your UEI? You can find your UEI or register for a new UEI by visiting SAM.gov.</p>
+          <p class="uei-explanation">Don’t know your UEI? You can find your UEI or register for a new UEI by visiting SAM.gov.</p>
 
         {% for i in inputs %}
           {% if i.field_type == "text" %}

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -9,6 +9,32 @@ uei-search:
         constraint: '== 12'
         error_message: UEI is twelve characters long
 
+modals:
+  - id: modal-uei-success
+    heading: Search Result
+    buttons:
+      - primary: Continue
+      - secondary: Go back
+    description: >
+      <p>Click continue to create a new audit submission for this auditee.</p>
+      <p>Not the auditee you’re looking for? Go back, check the UEI you entered, and try again.</p>
+  - id: modal-uei-connection-error
+    heading: We can't connect to SAM.gov to confirm your UEI.
+    buttons:
+      - primary: Go back
+      - secondary: Continue without a confirmed UEI
+    description: >
+      <p>We’re sorry for the delay. You can continue, but we’ll need confirm your UEI before your audit submission can be certified.</p>
+      <p>You might also want to check the UEI you entered, go back, and try again.</p>
+  - id: modal-uei-not-found
+    heading: Your UEI is not recognized
+    buttons:
+      - primary: Try again
+      - secondary: Continue without a confirmed UEI
+    description: >
+      <p>You can try re-entering the UEI. If you don’t have the UEI, you may find it at SAM.gov.</p>
+      <p>You may also continue without the UEI, and you will be prompted to update the UEI before you can submit your audit.</p>
+
 inputs:
   - id: auditee_name
     label: Auditee name
@@ -61,9 +87,10 @@ explanatory_text:
         <p>Search by Unique Entity Identifier (UEI) for your entity name in the SAM.gov database.</p>
         {{
           component('usa-search', {
-            id: 'auditee_ueid',
+            id: 'auditee_uei',
             baseUrl: config.baseUrl,
-            validations: uei-search.validations
+            validations: uei-search.validations,
+            controlsModal: 'uei-search-result'
           })
         }}
 
@@ -128,5 +155,51 @@ explanatory_text:
   </div>
 <script>const authToken = "{{ config.temporaryAuthToken }}"</script>
 <script src="{{ config.baseUrl }}assets/js/check-ueid.js"></script>
+
+  <div
+    class="usa-modal usa-modal--lg uei-search-result loading"
+    id="uei-search-result"
+    aria-labelledby="uei-search-result-heading"
+    aria-describedby="uei-search-result-description"
+  >
+    <div class="usa-modal__content">
+      <div class="usa-modal__main">
+        <img src="{{ config.baseUrl }}assets/img/loader.svg" alt="loading">
+        <h2 class="usa-modal__heading" id="uei-search-result-heading">
+        </h2>
+        <div class="usa-prose">
+          <p id="uei-search-result-description">
+          </p>
+        </div>
+        <div class="usa-modal__footer">
+          <ul class="usa-button-group">
+            <li class="usa-button-group__item">
+              <button type="button" class="usa-button" data-close-modal>
+              </button>
+            </li>
+            <li class="usa-button-group__item">
+              <button
+                type="button"
+                class="usa-button usa-button--unstyled padding-105 text-center"
+                data-close-modal
+              >
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <button
+        class="usa-button usa-modal__close"
+        aria-label="Close this window"
+        data-close-modal
+      >
+        <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+          <use xlink:href="/assets/img/sprite.svg#close"></use>
+        </svg>
+      </button>
+    </div>
+  </div>
+
 </div>
+
 {%- endblock -%}

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -105,7 +105,7 @@ explanatory_text:
             })
           }}
 
-          <p class="uei-explanation">Don’t know your UEI? You can find your UEI or register for a new UEI by visiting SAM.gov.</p>
+          <p class="uei-explanation">Don’t know your UEI? You can find your UEI or register for a new UEI by visiting <a href="https://sam.gov/">SAM.gov</a>.</p>
 
         {% for i in inputs %}
           {% if i.field_type == "text" %}

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -101,7 +101,8 @@ explanatory_text:
               id: 'auditee_uei',
               baseUrl: config.baseUrl,
               validations: uei_search.validations,
-              controlsModal: 'uei-search-result'
+              controlsModal: 'uei-search-result',
+              required: true
             })
           }}
 

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -1,37 +1,15 @@
 ---
 title: Create new audit
 
+uei-search:
+    validations:
+      - operation: not-null
+        error_message: Can't be null
+      - operation: length
+        constraint: '== 12'
+        error_message: UEI is twelve characters long
+
 inputs:
-  - id: auditee_ueid
-    label: Auditee Unique Entity Identifier (UEI)
-    required: true
-    field_type: text
-    validations:
-      - operation: not-null
-        error_message: Can't be null
-      - operation: length
-        constraint: '== 12'
-        error_message: UEI is twelve characters long
-
-  - id: confirm_auditee_ueid
-    label: Re-enter Auditee Unique Entity Identifier (UEI)
-    required: true
-    field_type: text
-    validations:
-      - operation: not-null
-        error_message: Can't be null
-      - operation: length
-        constraint: '== 12'
-        error_message: UEI is twelve characters long
-      - operation: must-match
-        constraint: auditee_ueid
-        error_message: This field should match the one before it
-
-  - id: check_ueid
-    label: Validate UEI
-    field_type: button
-    tooltip_text: Check SAM.gov for the UEI you entered. If UEI found, auditee name will autopopulate
-
   - id: auditee_name
     label: Auditee name
     disabled: true
@@ -79,6 +57,18 @@ explanatory_text:
             >*</abbr
           >Indicates a required field.
         </p>
+
+        <p>Search by Unique Entity Identifier (UEI) for your entity name in the SAM.gov database.</p>
+        {{
+          component('usa-search', {
+            id: 'auditee_ueid',
+            baseUrl: config.baseUrl,
+            validations: uei-search.validations
+          })
+        }}
+
+        <p>Don’t know your UEI? You can find your UEI or register for a new UEI by visiting SAM.gov.</p>
+
         {% for i in inputs %}
           {% if i.field_type == "text" %}
             {{
@@ -91,23 +81,6 @@ explanatory_text:
                 disabled: i.disabled
               })
             }}
-          {% elif i.field_type == "button" %}
-          <div class="usa-form-group validate-uei">
-            <ul class="usa-error-message"
-              id="uei-error-message"
-              role="alert"
-              >
-            </ul>
-            <button class="usa-button
-                           usa-button--secondary
-                           usa-button--unstyled
-                           usa-tooltip"
-                    data-position="right"
-                    title="{{ i.tooltip_text }}"
-                    id="validate-UEI">
-              {{ i.label }}
-            </button>
-          </div>
           {% elif i.field_type == "date" %}
           <div class="usa-form-group validate-fy">
             {% if i.id == "auditee_fy_start_date_start" %}

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -84,17 +84,17 @@ explanatory_text:
           >Indicates a required field.
         </p>
 
-        <p>Search by Unique Entity Identifier (UEI) for your entity name in the SAM.gov database.</p>
-        {{
-          component('usa-search', {
-            id: 'auditee_uei',
-            baseUrl: config.baseUrl,
-            validations: uei-search.validations,
-            controlsModal: 'uei-search-result'
-          })
-        }}
+          <p>Search by Unique Entity Identifier (UEI) for your entity name in the SAM.gov database.</p>
+          {{
+            component('usa-search', {
+              id: 'auditee_uei',
+              baseUrl: config.baseUrl,
+              validations: uei-search.validations,
+              controlsModal: 'uei-search-result'
+            })
+          }}
 
-        <p>Don’t know your UEI? You can find your UEI or register for a new UEI by visiting SAM.gov.</p>
+          <p>Don’t know your UEI? You can find your UEI or register for a new UEI by visiting SAM.gov.</p>
 
         {% for i in inputs %}
           {% if i.field_type == "text" %}

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -167,20 +167,18 @@ explanatory_text:
         <img src="{{ config.baseUrl }}assets/img/loader.svg" alt="loading">
         <h2 class="usa-modal__heading" id="uei-search-result-heading">
         </h2>
-        <div class="usa-prose">
-          <p id="uei-search-result-description">
-          </p>
+        <div class="usa-prose" id="uei-search-result-description">
         </div>
         <div class="usa-modal__footer">
           <ul class="usa-button-group">
             <li class="usa-button-group__item">
-              <button type="button" class="usa-button" data-close-modal>
+              <button type="button" class="usa-button primary" data-close-modal>
               </button>
             </li>
             <li class="usa-button-group__item">
               <button
                 type="button"
-                class="usa-button usa-button--unstyled padding-105 text-center"
+                class="usa-button usa-button--unstyled padding-105 text-center secondary"
                 data-close-modal
               >
               </button>

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -1,3 +1,5 @@
+import { getApiToken } from './auth';
+
 export const queryAPI = (
   endpoint,
   data,
@@ -7,15 +9,18 @@ export const queryAPI = (
   const apiUrl = 'https://fac-dev.app.cloud.gov';
   const headers = new Headers();
 
-  headers.append('Authorization', 'Basic ' + config.authToken); // authToken is set in a script tag right before this script loads
   headers.append('Content-type', 'application/json');
 
-  fetch(apiUrl + endpoint, {
-    method: config.method,
-    headers: headers,
-    body: JSON.stringify(data),
-  })
-    .then((resp) => resp.json())
-    .then((data) => handleResponse(data))
-    .catch((e) => handleError(e));
+  getApiToken().then((token) => {
+    headers.append('Authorization', 'Token ' + token); // authToken is set in a script tag right before this script loads
+
+    fetch(apiUrl + endpoint, {
+      method: config.method,
+      headers: headers,
+      body: JSON.stringify(data),
+    })
+      .then((resp) => resp.json())
+      .then((data) => handleResponse(data))
+      .catch((e) => handleError(e));
+  });
 };

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -211,7 +211,6 @@ function validateUEID() {
     '/sac/ueivalidation',
     { auditee_uei },
     {
-      /* eslint-disable-next-line no-undef */
       method: 'POST',
     },
     [handleUEIDResponse, handleApiError]

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -44,15 +44,8 @@ function handleUEIDResponse({ valid, response, errors }) {
 }
 
 function handleValidUei({ auditee_name }) {
-  const ueiFormGroup = document.querySelector('.usa-form-group.usa-search');
-  const errorContainer = document.getElementById('auditee_uei-error-message');
-
   document.getElementById('auditee_name').value = auditee_name;
   populateModal('success', auditee_name);
-
-  errorContainer.hidden = true;
-  errorContainer.innerHTML = '';
-  ueiFormGroup.classList.remove('usa-form-group--error');
 }
 
 function handleInvalidUei(errors) {
@@ -91,6 +84,31 @@ function hideUeiStuff() {
   [...ueiExplanations, ueiFormGroup].forEach((node) =>
     node.setAttribute('hidden', 'true')
   );
+}
+
+function showValidUeiInfo() {
+  const auditeeUei = document.getElementById('auditee_uei').value;
+  const auditeeName = document.getElementById('auditee_name').value;
+  const ueiInfoEl = document.createElement('div');
+
+  ueiInfoEl.innerHTML = `
+    <dl>
+      <dt>Unique Entity ID</dt>
+      <dd>${auditeeUei}</dd>
+      <dt>Auditee name</dt>
+      <dd>${auditeeName}</dd>
+    </dl>
+  `;
+
+  document
+    .getElementById('auditee_name')
+    .parentNode.setAttribute('hidden', 'true');
+  document.getElementById('no-uei-warning').replaceWith(ueiInfoEl);
+}
+
+function setupFormWithValidUei() {
+  hideUeiStuff();
+  showValidUeiInfo();
 }
 
 // 'connection-error' | 'not-found' | 'success'
@@ -170,6 +188,10 @@ function populateModal(formStatus, auditeeName) {
   modalDescriptionEl.innerHTML = contentForStatus.description;
   modalButtonPrimaryEl.textContent = contentForStatus.buttons.primary.text;
   modalButtonSecondaryEl.textContent = contentForStatus.buttons.secondary.text;
+
+  if (formStatus == 'success') {
+    modalButtonPrimaryEl.onclick = setupFormWithValidUei;
+  }
 
   if (formStatus == 'not-found') {
     modalButtonPrimaryEl.onclick = proceedWithoutUei;

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -92,7 +92,7 @@ function showValidUeiInfo() {
   const ueiInfoEl = document.createElement('div');
 
   ueiInfoEl.innerHTML = `
-    <dl>
+    <dl data-testid="uei-info">
       <dt>Unique Entity ID</dt>
       <dd>${auditeeUei}</dd>
       <dt>Auditee name</dt>

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -1,6 +1,7 @@
 import { checkValidity } from './validate';
 import { queryAPI } from './api';
 import { getApiToken } from './auth';
+import modal from '@uswds/uswds/js/usa-modal';
 
 const ENDPOINT = 'https://fac-dev.app.cloud.gov/sac/auditee';
 //const ENDPOINT = '/sac/auditee';
@@ -70,9 +71,21 @@ function handleInvalidUei(errors) {
 }
 
 function handleApiError() {
-  const errorMsg = `We can’t connect to SAM.gov to confirm your UEI. We're sorry for the delay. You can continue, but we'll need to confirm your UEI before your audit can be certified.`;
-
+  const errorMsg = 'oops';
+  const id = 'modal-uei-connection-error';
+  attachModal(id);
+  const modalEl = document.getElementById(id);
+  console.log(modalEl);
+  console.log(modal);
+  modal.toggleModal.call(modalEl, true);
   handleInvalidUei({ uei: [errorMsg] });
+}
+
+// 'connection-error' | 'not-found' | 'success'
+function attachModal(formStatus) {
+  const modalTmpl = document.getElementById(`${formStatus}-tmpl`);
+  const modalEl = modalTmpl.content.cloneNode(true);
+  document.body.appendChild(modalEl);
 }
 
 function validateUEID() {
@@ -134,7 +147,7 @@ function performValidations(field) {
 }
 
 function attachEventHandlers() {
-  const btnValidateUEI = document.getElementById('auditee_ueid-btn');
+  const btnValidateUEI = document.getElementById('auditee_uei-btn');
   btnValidateUEI.addEventListener('click', (e) => {
     e.preventDefault();
     validateUEID();

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -56,17 +56,9 @@ function handleValidUei({ auditee_name }) {
 }
 
 function handleInvalidUei(errors) {
-  const ueiFormGroup = document.querySelector('.usa-form-group.usa-search');
-  const errorContainer = document.getElementById('auditee_uei-error-message');
-  ueiFormGroup.classList.add('usa-form-group--error');
-
-  errors.uei.forEach((error) => {
-    const errorEl = document.createElement('li');
-    errorEl.innerText = error;
-    errorContainer.appendChild(errorEl);
-  });
-
-  errorContainer.hidden = false;
+  if (Object.keys(errors).includes('auditee_uei')) {
+    populateModal('not-found');
+  }
 }
 
 function handleApiError(e) {

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -113,7 +113,7 @@ function performValidations(field) {
 }
 
 function attachEventHandlers() {
-  const btnValidateUEI = document.getElementById('validate-UEI');
+  const btnValidateUEI = document.getElementById('auditee_ueid-btn');
   btnValidateUEI.addEventListener('click', (e) => {
     e.preventDefault();
     validateUEID();

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -66,6 +66,33 @@ function handleApiError(e) {
   console.error(e);
 }
 
+function proceedWithoutUei() {
+  const nameInputEl = document.getElementById('auditee_name');
+  const requiredStar = document.createElement('abbr');
+
+  requiredStar.setAttribute('title', 'required');
+  requiredStar.setAttribute('class', 'usa-hint usa-hint--required');
+  requiredStar.textContent = '*';
+
+  nameInputEl.removeAttribute('disabled');
+  nameInputEl.setAttribute('required', 'true');
+  document.querySelector('[for=auditee_name]').appendChild(requiredStar);
+  document.getElementById('no-uei-warning').hidden = false;
+
+  hideUeiStuff();
+}
+
+function hideUeiStuff() {
+  const ueiFormGroup =
+    document.getElementById('auditee_uei').parentNode.parentNode;
+  const ueiExplanations = Array.from(
+    document.querySelectorAll('.uei-explanation')
+  );
+  [...ueiExplanations, ueiFormGroup].forEach((node) =>
+    node.setAttribute('hidden', 'true')
+  );
+}
+
 // 'connection-error' | 'not-found' | 'success'
 function populateModal(formStatus, auditeeName) {
   const auditeeUei = document.getElementById('auditee_uei').value;
@@ -95,7 +122,9 @@ function populateModal(formStatus, auditeeName) {
         primary: {
           text: `Go back`,
         },
-        secondary: { text: `Continue without a confirmed UEI` },
+        secondary: {
+          text: `Continue without a confirmed UEI`,
+        },
       },
     },
     success: {
@@ -141,6 +170,15 @@ function populateModal(formStatus, auditeeName) {
   modalDescriptionEl.innerHTML = contentForStatus.description;
   modalButtonPrimaryEl.textContent = contentForStatus.buttons.primary.text;
   modalButtonSecondaryEl.textContent = contentForStatus.buttons.secondary.text;
+
+  if (formStatus == 'not-found') {
+    modalButtonPrimaryEl.onclick = proceedWithoutUei;
+  }
+
+  if (formStatus == 'connection-error') {
+    modalButtonSecondaryEl.onclick = proceedWithoutUei;
+  }
+
   document.querySelector('.uei-search-result').classList.remove('loading');
 }
 

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -3,7 +3,6 @@ import { queryAPI } from './api';
 import { getApiToken } from './auth';
 
 const ENDPOINT = 'https://fac-dev.app.cloud.gov/sac/auditee';
-//const ENDPOINT = '/sac/auditee';
 const FORM = document.forms[0];
 
 function submitForm() {

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -1,7 +1,6 @@
 import { checkValidity } from './validate';
 import { queryAPI } from './api';
 import { getApiToken } from './auth';
-import modal from '@uswds/uswds/js/usa-modal';
 
 const ENDPOINT = 'https://fac-dev.app.cloud.gov/sac/auditee';
 //const ENDPOINT = '/sac/auditee';
@@ -71,21 +70,42 @@ function handleInvalidUei(errors) {
 }
 
 function handleApiError() {
-  const errorMsg = 'oops';
-  const id = 'modal-uei-connection-error';
-  attachModal(id);
-  const modalEl = document.getElementById(id);
-  console.log(modalEl);
-  console.log(modal);
-  modal.toggleModal.call(modalEl, true);
-  handleInvalidUei({ uei: [errorMsg] });
+  populateModal('connection-error');
 }
 
 // 'connection-error' | 'not-found' | 'success'
-function attachModal(formStatus) {
-  const modalTmpl = document.getElementById(`${formStatus}-tmpl`);
-  const modalEl = modalTmpl.content.cloneNode(true);
-  document.body.appendChild(modalEl);
+function populateModal(formStatus) {
+  const modalContainerEl = document.querySelector(
+    '#uei-search-result .usa-modal__main'
+  );
+  const modalHeadingEl = modalContainerEl.querySelector('h2');
+  const modalDescriptionEl = modalContainerEl.querySelector(
+    '#uei-search-result-description'
+  );
+  const modalButtonPrimaryEl = modalContainerEl.querySelector('button.primary');
+  const modalButtonSecondaryEl =
+    modalContainerEl.querySelector('button.secondary');
+
+  const modalContent = {
+    'connection-error': {
+      heading: `We can't connect to SAM.gov to confirm your UEI.`,
+      description: `<p>We’re sorry for the delay. You can continue, but we’ll need confirm your UEI before your audit submission can be certified.</p>
+                    <p>You might also want to check the UEI you entered, go back, and try again.</p>`,
+      buttons: {
+        primary: {
+          text: `Go back`,
+        },
+        secondary: { text: `Continue without a confirmed UEI` },
+      },
+    },
+  };
+
+  const contentForStatus = modalContent[formStatus];
+  modalHeadingEl.textContent = contentForStatus.heading;
+  modalDescriptionEl.innerHTML = contentForStatus.description;
+  modalButtonPrimaryEl.textContent = contentForStatus.buttons.primary.text;
+  modalButtonSecondaryEl.textContent = contentForStatus.buttons.secondary.text;
+  document.querySelector('.uei-search-result').classList.remove('loading');
 }
 
 function validateUEID() {

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -171,7 +171,7 @@ function populateModal(formStatus, auditeeName) {
           <dt>UEI you entered</dt>
           <dd>${auditeeUei}</dd>
         </dl>
-        <p>You can try re-entering the UEI. If you don’t have the UEI, you may find it at SAM.gov.</p>
+        <p>You can try re-entering the UEI. If you don’t have the UEI, you may find it at <a href="https://sam.gov">SAM.gov</a>.</p>
         <p>You may also continue without the UEI, and you will be prompted to update the UEI before you can submit your audit.</p>
       `,
       buttons: {

--- a/src/js/validate.js
+++ b/src/js/validate.js
@@ -97,6 +97,7 @@ export const validations = {
 
     switch (field.type) {
       case 'text':
+      case 'search':
         return !field.value ? { ...result, error: true } : result;
       case 'radio':
         return !field.checked ? { ...result, error: true } : result;

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -113,6 +113,18 @@ ul.usa-error-message {
   }
 }
 
+.auditee-information dd,
+.uei-search-result dd {
+  font-weight: bold;
+  margin-left: 0;
+  margin-bottom: 1rem;
+}
+
+.auditee-information dl,
+.uei-search-result dl {
+  margin-bottom: 2rem;
+}
+
 .uei-search-result {
   img {
     display: none;

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -146,7 +146,6 @@ ul.usa-error-message {
 
   h2 {
     font-size: size('body', 8);
-    line-height: 0.5rem;
   }
 
   .usa-icon {

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -130,6 +130,19 @@ ul.usa-error-message {
   }
 }
 
+#no-uei-warning {
+  color: color('secondary');
+
+  h2 {
+    font-size: size('body', 8);
+    line-height: .5rem;
+  }
+
+  .usa-icon {
+    top: .1em;
+  }
+}
+
 .delete-contact {
   margin: 0 !important;
   margin-top: auto !important;

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -47,7 +47,6 @@ ul.usa-error-message {
   .grid-container {
     padding-left: 0;
   }
-
 }
 
 #check-eligibility .usa-search__submit-text {
@@ -103,7 +102,7 @@ ul.usa-error-message {
   }
 
   #uei-success {
-    margin-top: .5em;
+    margin-top: 0.5em;
 
     & svg {
       fill: #538200;
@@ -147,18 +146,18 @@ ul.usa-error-message {
 
   h2 {
     font-size: size('body', 8);
-    line-height: .5rem;
+    line-height: 0.5rem;
   }
 
   .usa-icon {
-    top: .1em;
+    top: 0.1em;
   }
 }
 
 .delete-contact {
   margin: 0 !important;
   margin-top: auto !important;
-  margin-bottom: .5rem !important;
+  margin-bottom: 0.5rem !important;
   padding: 0 !important;
 
   .usa-icon {
@@ -169,7 +168,7 @@ ul.usa-error-message {
 }
 
 /* stylelint-disable */
-#auditee_name {
+#auditee_name[disabled] {
   cursor: not-allowed;
 }
 
@@ -185,8 +184,8 @@ ul.usa-error-message {
     top: 0;
 
     .usa-sidenav a:not([href]),
-    .usa-sidenav a:not([href]):hover, 
-    .usa-sidenav a:not([href]):active, 
+    .usa-sidenav a:not([href]):hover,
+    .usa-sidenav a:not([href]):active,
     .usa-sidenav a:not([href]):visited {
       color: #72777a;
       cursor: not-allowed;
@@ -203,7 +202,9 @@ ul.usa-error-message {
       }
     }
 
-    .usa-sidenav .usa-current { font-weight: bold;}
+    .usa-sidenav .usa-current {
+      font-weight: bold;
+    }
   }
 }
 
@@ -215,7 +216,7 @@ ul.usa-error-message {
     font-weight: bold;
 
     &::after {
-      content: ":";
+      content: ':';
     }
   }
 
@@ -228,7 +229,7 @@ ul.usa-error-message {
   fieldset:not(.radio) {
     margin-bottom: units(4);
 
-    fieldset { 
+    fieldset {
       margin-top: units(4);
 
       legend {

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -113,6 +113,23 @@ ul.usa-error-message {
   }
 }
 
+.uei-search-result {
+  img {
+    display: none;
+    margin: auto;
+  }
+
+  &.loading {
+    button {
+      display: none;
+    }
+
+    img {
+      display: block;
+    }
+  }
+}
+
 .delete-contact {
   margin: 0 !important;
   margin-top: auto !important;

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -50,6 +50,17 @@ ul.usa-error-message {
 
 }
 
+#check-eligibility .usa-search__submit-text {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+
+  img {
+    display: block !important;
+  }
+}
+
 .auditee-information {
   background-color: #f0f0f0;
   max-width: 100%;


### PR DESCRIPTION
This PR implements the new flow that allows users to proceed creating an audit even if they don't have a valid UEI (GSA-TTS/FAC#285)

## Walkthrough of key functionality and QA notes

### Connection error state

I'd suggest trying it once not logged in to see the API failure state (it'll `401` but the connection failure status doesn't differentiate between all of the ways the API call could fail). 

<img width="1030" alt="image" src="https://user-images.githubusercontent.com/6290/179276845-c29ffcad-febd-4cbb-8199-3ccc285cd004.png">

If you click the `Go Back` button, it should just dismiss the modal and let you try again. If you click the other one it takes you to the no UEI flow:

<img width="511" alt="image" src="https://user-images.githubusercontent.com/6290/179277184-4382e43a-7654-4e14-a22c-f66080e308a5.png">

### Invalid UEI state

To see the other states, you'll need to log in [at the homepage](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh-no-uei-285/) first, but once you're logged in you can skip to the [Auditee Information](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh-no-uei-285/audit/new/step-2/) page (which you probably _shouldn't_ be able to do but that's another ticket. 

If you put in a bad UEI, you get the UEI not recognized state

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/6290/179277684-99d0a633-9834-400e-80b5-1e260753c5e4.png">

This one works opposite to the connection failure modal in that the primary button is the one to go ahead without a UEI and the secondary one closes the modal so the user can try again.

### Success

For the happy path, just put in a good UEI and you get:

<img width="997" alt="image" src="https://user-images.githubusercontent.com/6290/179279290-657ced74-0f14-4a9a-9007-883a3be90b2e.png">

If you continue, it hides the UEI & Auditee Name fields (and explanatory text) and replaces them with non-editable versions of the UEI & Name text:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/6290/179279608-eaa9645f-783b-4011-99b1-b1befa3d4e6d.png">



