### PR TITLE
Include all_emails scope in auth request

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -11,7 +11,7 @@ const settings = {
   redirect_uri: fullBaseUrl + 'auth/post-login', // baseUrl is set in a script tag right before this script loads
   post_logout_redirect_uri: fullBaseUrl,
   response_type: 'code',
-  scope: 'openid email roles',
+  scope: 'openid email roles all_emails',
 
   response_mode: 'query',
 


### PR DESCRIPTION
Relates to [320](https://github.com/GSA-TTS/FAC/issues/320)

Adds `all_emails` scope to Login.gov authorize request