### PR TITLE
Revert 'my submissions' login redirect

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -66,7 +66,7 @@ export const getApiToken = () => {
         })
           .then((resp) => resp.json())
           .then((data) => tokenStore.set('fac-api-token', data.token))
-          .then(() => (window.location = appBaseUrl + 'submissions'));
+          .then(() => (window.location = appBaseUrl + 'audit/new/step-1'));
       });
     }
   }


### PR DESCRIPTION
A redirect was put in place in https://github.com/GSA-TTS/FAC-Frontend/pull/33. We don't want to always redirect people to the audit submissions page. We're closing in on an exact AC in https://github.com/GSA-TTS/FAC/issues/388, but it's out of scope in this issue. This came up as I was testing Milestone 1 end to end. I suggest we revert the routing change you did for now so we test that end to end. 