### PR TITLE
Implement logout button

### DIFF
--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -6,6 +6,7 @@
           type: 'success',
           id: 'logout-success',
           text: 'You have successfully logged out',
+          hidden: true,
           slim: true
         })
       }}

--- a/src/_includes/components/hero.njk
+++ b/src/_includes/components/hero.njk
@@ -1,5 +1,22 @@
+{%- from "system/component.njk" import component -%}
   <section class="usa-hero" aria-label="Introduction">
     <div class="grid-container">
+      {{
+        component('usa-alert', {
+          type: 'success',
+          id: 'logout-success',
+          text: 'You have successfully logged out',
+          slim: true
+        })
+      }}
+      <script>
+        (function(){
+          const params = new URLSearchParams(window.location.search);
+          if (params.has('logout')) {
+            document.getElementById('logout-success').hidden = false;
+          }
+        })()
+      </script>
       <h1 class="usa-hero__heading">{{ hero.callout.text }}</h1>
       <p>{{ hero.content | safe }}</p>
       <div class="usa-button-group">

--- a/src/_includes/components/usa-alert.njk
+++ b/src/_includes/components/usa-alert.njk
@@ -1,6 +1,12 @@
-<div class="usa-alert usa-alert--{{ params.type }}" role="alert">
+<div class="usa-alert usa-alert--{{ params.type }} {{ "usa-alert--slim" if params.slim }}" 
+  role="alert" 
+  {{ "hidden" if params.hidden}}
+  {{ "id=" + params.id if params.id }}
+>
   <div class="usa-alert__body">
-    <h4 class="usa-alert__heading">{{ params.heading }}</h4>
+    {% if not params.slim %}
+      <h4 class="usa-alert__heading">{{ params.heading }}</h4>
+    {% endif %}
     <p class="usa-alert__text">
       {{ params.text }}
     </p>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -74,7 +74,6 @@
                           <p>Collecting data on behalf of OMB. Version: 1.4.14.0   Last Modified: February 09, 2022 and expires February 28, 2025</p>'
           })
         }}
-        <script src="sign-in.js"></script>
       </div>
     </nav>
   </div>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -48,33 +48,46 @@
           {% endif %}
         {% endfor %}
       </ul>
-      <div class="sign-in">
-        <a 
-          class="sign-in-logo" 
-          aria-controls="login-modal"
-          href="#login-modal" 
-          data-open-modal
-          tabindex="0"
-          >
-          Submit an audit
-        </a>
-        {{
-          component('usa-modal', {
-            id: 'login-modal',
-            heading: 'Submitting information to the Federal Audit Clearinghouse requires authentication',
-            continueButton: {
-              text: 'Authenticate with Login.gov',
-              id: 'sign-in',
-              class: 'sign-in-button'
-            },
-            backButtonText: 'Go back',
-            description: '<p>General Services Administration Notice and Consent Warning</p>
-                          <p>You are accessing a United States government computer system. This United States government computer system is provided for the collection of the single audit reporting package and form SF-SAC as required under the Single Audit Act of 1984 (amended in 1996) and the Office of Management and Budget (OMB) Title 2 U.S. Code of Federal Regulations (CFR) Part 200, Uniform Administrative Requirements for Federal Awards (Uniform Guidance).</p>
-                          <p>Use of this system indicates your consent to collection, monitoring, recording, and use of the information you provide for any lawful government purpose. So that our network remains safe and available for its intended use, network traffic is monitored to identify unauthorized attempts to access, upload, change information, or otherwise cause damage to the web service. Use of a government computer network for unauthorized purposes is a violation of federal law and punishable by fines or imprisonment (Public Law 99-474).</p>
-                          <p>Collecting data on behalf of OMB. Version: 1.4.14.0   Last Modified: February 09, 2022 and expires February 28, 2025</p>'
-          })
-        }}
-      </div>
+
+      {% if page.url == "/" %}
+        <div class="sign-in">
+          <a 
+            class="sign-in-logo" 
+            aria-controls="login-modal"
+            href="#login-modal" 
+            data-open-modal
+            tabindex="0"
+            >
+            Submit an audit
+          </a>
+          {{
+            component('usa-modal', {
+              id: 'login-modal',
+              heading: 'Submitting information to the Federal Audit Clearinghouse requires authentication',
+              continueButton: {
+                text: 'Authenticate with Login.gov',
+                id: 'sign-in',
+                class: 'sign-in-button'
+              },
+              backButtonText: 'Go back',
+              description: '<p>General Services Administration Notice and Consent Warning</p>
+                            <p>You are accessing a United States government computer system. This United States government computer system is provided for the collection of the single audit reporting package and form SF-SAC as required under the Single Audit Act of 1984 (amended in 1996) and the Office of Management and Budget (OMB) Title 2 U.S. Code of Federal Regulations (CFR) Part 200, Uniform Administrative Requirements for Federal Awards (Uniform Guidance).</p>
+                            <p>Use of this system indicates your consent to collection, monitoring, recording, and use of the information you provide for any lawful government purpose. So that our network remains safe and available for its intended use, network traffic is monitored to identify unauthorized attempts to access, upload, change information, or otherwise cause damage to the web service. Use of a government computer network for unauthorized purposes is a violation of federal law and punishable by fines or imprisonment (Public Law 99-474).</p>
+                            <p>Collecting data on behalf of OMB. Version: 1.4.14.0   Last Modified: February 09, 2022 and expires February 28, 2025</p>'
+            })
+          }}
+        </div>
+      {% else %}
+        <div class="sign-out">
+          <button class="usa-button usa-button--unstyled">
+            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+            <use xlink:href="{{ config.baseUrl }}assets/img/sprite.svg#logout"></use> 
+            </svg>
+            <span>Sign out</span>
+            <span class="user-info" id="user-info"></span>
+          </button>
+        </div>
+      {% endif %}
     </nav>
   </div>
 </header>

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -1,5 +1,6 @@
 import { UserManager, WebStorageStateStore } from 'oidc-client-ts';
 import crypto from 'crypto-js';
+import { queryAPI } from './api';
 
 /* eslint-disable-next-line no-undef */
 const appBaseUrl = typeof baseUrl !== 'undefined' ? baseUrl : '/';
@@ -9,10 +10,10 @@ const settings = {
   authority: 'https://idp.int.identitysandbox.gov',
   client_id: 'urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:gsa-fac-pkce-01',
   redirect_uri: fullBaseUrl + 'auth/post-login', // baseUrl is set in a script tag right before this script loads
-  post_logout_redirect_uri: fullBaseUrl,
+  post_logout_redirect_uri: fullBaseUrl + '?logout=success',
   response_type: 'code',
   scope: 'openid email roles all_emails',
-
+  end_session_endpoint: 'http://fac-dev.app.cloud.gov/api/auth/token',
   response_mode: 'query',
 
   automaticSilentRenew: false,
@@ -47,6 +48,34 @@ export const getApiToken = () => {
     });
   }
 
+  function handleLogoutSuccess() {
+    sessionStorage.clear();
+    localStorage.removeItem();
+    window.location = settings.post_logout_redirect_uri;
+  }
+
+  function handleLogoutError(e) {
+    console.error(e);
+  }
+
+  function logout() {
+    queryAPI(
+      '/api/auth/token',
+      {},
+      {
+        method: 'DELETE',
+      },
+      [handleLogoutSuccess, handleLogoutError]
+    );
+  }
+
+  function getUserInfo() {
+    const userInfoCtr = document.getElementById('user-info');
+    userManager
+      .getUser()
+      .then(({ profile }) => (userInfoCtr.innerText = profile.email));
+  }
+
   function attachEventHandlers() {
     attachSignInButtonHandler();
 
@@ -69,6 +98,16 @@ export const getApiToken = () => {
           .then(() => (window.location = appBaseUrl + 'audit/new/step-1'));
       });
     }
+
+    const signOutBtn = document.querySelector('.sign-out button');
+    if (signOutBtn) {
+      signOutBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        logout();
+      });
+    }
+
+    window.addEventListener('load', getUserInfo);
   }
 
   function init() {

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -50,7 +50,7 @@ export const getApiToken = () => {
 
   function handleLogoutSuccess() {
     sessionStorage.clear();
-    localStorage.removeItem();
+    localStorage.removeItem('oidc.fac-api-token');
     window.location = settings.post_logout_redirect_uri;
   }
 
@@ -71,9 +71,11 @@ export const getApiToken = () => {
 
   function getUserInfo() {
     const userInfoCtr = document.getElementById('user-info');
-    userManager
-      .getUser()
-      .then(({ profile }) => (userInfoCtr.innerText = profile.email));
+    userManager.getUser().then((user) => {
+      if (user) {
+        userInfoCtr.innerText = user.profile.email;
+      }
+    });
   }
 
   function attachEventHandlers() {

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -1,6 +1,6 @@
 @use 'uswds-core' as *;
 
-@media (min-width: 64em) { 
+@media (min-width: 64em) {
   .usa-logo {
     margin: 0;
   }
@@ -14,9 +14,10 @@
   }
 }
 
-.sign-in {
+.sign-in,
+.sign-out {
   background-color: color('primary-darker');
-  padding: .5em 1.5em 1.5em 1em;
+  padding: 0.5em 1.5em 1.5em 1em;
 }
 
 .usa-menu-btn {
@@ -25,7 +26,7 @@
 
 .sign-in-logo,
 .sign-in-logo:active,
-.sign-in-logo:visited  {
+.sign-in-logo:visited {
   color: #fff;
   font-weight: bold;
   margin: 0;
@@ -36,6 +37,36 @@
   text-decoration: none;
 }
 
+.sign-out {
+  padding: 1.8rem 2.8rem 1.8rem 1.4rem;
+
+  button {
+    color: #fff;
+    display: flex;
+    flex-flow: column wrap;
+    height: 2em;
+    text-decoration: none;
+
+    &:hover {
+      color: #fff;
+    }
+
+    span {
+      font-size: size('body', 'xs');
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 10rem;
+    }
+
+    svg {
+      font-size: size('body', 9);
+      height: 2em;
+    }
+  }
+}
+
+.sign-out button:hover,
 .sign-in-logo:hover {
   text-decoration: underline;
 }
@@ -43,11 +74,11 @@
 .sign-in-logo::before {
   content: url('../../assets/img/login-logo.png');
   position: relative;
-  top: .5em;
+  top: 0.5em;
 }
 
 .usa-header {
-  background-color: #F3F9FE;
+  background-color: #f3f9fe;
 
   .usa-logo a {
     color: color('primary-darker');

--- a/src/scss/_home.scss
+++ b/src/scss/_home.scss
@@ -40,3 +40,11 @@
     max-width: 45rem;
   }
 }
+
+.usa-alert {
+  &--slim {
+    p {
+      margin-bottom: 0;
+    }
+  }
+}


### PR DESCRIPTION
This PR implements GSA-TTS/FAC#378, which is the front-end portion of GSA-TTS/FAC#359.

After logging in, the login button is replaced with a button showing the logged-in user's email address and allowing them to log out:

<img width="333" alt="image" src="https://user-images.githubusercontent.com/6290/181340125-905ec397-978f-4d37-85fd-c2a106cc02d9.png">

After logging out, the user will be redirected to the FAC homepage and shown an alert letting them know they have logged out:

![image](https://user-images.githubusercontent.com/6290/181353970-3a2dffab-e2d6-41a4-bf05-b5669f0c835f.png)

Unfortunately, I don't think there's a ton that we can meaningfully test here. Cypress has [experimental support](https://docs.cypress.io/api/commands/session#Syntax) for session storage, but I don't want to invest time in an unstable API.

[:eyes: [federalist preview](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh/logout-378/)]