### PR TITLE
Make date inputs required

### DIFF
--- a/cypress/integration/check-ueid.spec.js
+++ b/cypress/integration/check-ueid.spec.js
@@ -5,7 +5,7 @@ describe('Create New Audit', () => {
 
   describe('A Blank Form', () => {
     it('marks empty responses as invalid', () => {
-      cy.get('.auditee-information input:invalid').should('have.length', 1);
+      cy.get('.auditee-information input:invalid').should('have.length', 3);
     });
 
     it('will not submit', () => {

--- a/cypress/integration/check-ueid.spec.js
+++ b/cypress/integration/check-ueid.spec.js
@@ -57,8 +57,25 @@ describe('Create New Audit', () => {
       });
     });
 
-    describe('Fiscal Year Validation', () => {
+    describe('Fiscal Year Start Validation', () => {
+      it('should display an error message when left blank', () => {
+        cy.get('#auditee_fiscal_period_start').click().blur();
+        cy.get('#auditee_fiscal_period_start-not-null').should('be.visible');
+      });
+
+      it('should disable the submit button when fields are invalid', () => {
+        cy.get('button').contains('Continue').should('be.disabled');
+      });
+
+      it('should remove the error message when input is supplied', () => {
+        cy.get('#auditee_fiscal_period_start').type('01/01/2022').blur();
+        cy.get('#auditee_fiscal_period_start-not-null').should(
+          'not.be.visible'
+        );
+      });
+
       it('should show an error if the user enters a date before 1/1/2020', () => {
+        cy.get('#auditee_fiscal_period_start').clear();
         cy.get('#auditee_fiscal_period_start').type('12/31/2019');
         cy.get('#fy-error-message li').should('have.length', 1);
       });
@@ -66,6 +83,21 @@ describe('Create New Audit', () => {
       it('should not show an error if the user enters a date after 12/31/2019', () => {
         cy.get('#auditee_fiscal_period_start').clear().type('12/31/2020');
         cy.get('#fy-error-message li').should('have.length', 0);
+      });
+    });
+    describe('Fiscal Year End Validation', () => {
+      it('should display an error message when left blank', () => {
+        cy.get('#auditee_fiscal_period_end').click().blur();
+        cy.get('#auditee_fiscal_period_end-not-null').should('be.visible');
+      });
+
+      it('should disable the submit button when fields are invalid', () => {
+        cy.get('button').contains('Continue').should('be.disabled');
+      });
+
+      it('should remove the error message when input is supplied', () => {
+        cy.get('#auditee_fiscal_period_end').type('01/31/2022').blur();
+        cy.get('#auditee_fiscal_period_end-not-null').should('not.be.visible');
       });
     });
 

--- a/src/_includes/components/usa-date-picker.njk
+++ b/src/_includes/components/usa-date-picker.njk
@@ -7,6 +7,21 @@
   </label>
   <div class="usa-hint" id="{{ params.id }}-hint">mm/dd/yyyy</div>
   <div class="usa-date-picker">
+    {% if params.validations %}
+    <ul class="usa-error-message"
+      id="{{ params.id }}-error-message"
+      role="alert"
+      >
+      {% for v in params.validations %}
+        <li
+          id="{{ params.id }}-{{ v.operation }}"
+          hidden
+          >
+          {{ v.error_message }}
+        </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
     <input
       class="usa-input"
       id="{{ params.id }}"
@@ -17,6 +32,9 @@
         aria-required="true"
         required
       {% endif %}
+      {% for v in params.validations %}
+        data-validate-{{v.operation}}="{{v.constraint}}"
+      {% endfor %}
     />
   </div>
 </div>

--- a/src/_includes/components/usa-date-picker.njk
+++ b/src/_includes/components/usa-date-picker.njk
@@ -13,6 +13,10 @@
       name="{{ params.id }}"
       aria-labelledby="{{ params.id }}-label"
       aria-describedby="{{ params.id }}-hint"
+      {% if params.required %}
+        aria-required="true"
+        required
+      {% endif %}
     />
   </div>
 </div>

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -43,10 +43,12 @@ inputs:
     error_message: Auditee Name is required if proceeding without a valid UEI
 
   - id: auditee_fiscal_period_start
+    required: true
     label: Auditee fiscal period <strong>start</strong> date for this submission
     field_type: date
 
   - id: auditee_fiscal_period_end
+    required: true
     label: Auditee fiscal period <strong>end</strong> date for this submission
     field_type: date
 

--- a/src/audit/new/step-2/index.njk
+++ b/src/audit/new/step-2/index.njk
@@ -46,11 +46,17 @@ inputs:
     required: true
     label: Auditee fiscal period <strong>start</strong> date for this submission
     field_type: date
+    validations:
+      - operation: not-null
+        error_message: Can't be null
 
   - id: auditee_fiscal_period_end
     required: true
     label: Auditee fiscal period <strong>end</strong> date for this submission
     field_type: date
+    validations:
+      - operation: not-null
+        error_message: Can't be null
 
 explanatory_text:
   heading: The unique entity identifier used by the FAC has changed.
@@ -137,7 +143,8 @@ explanatory_text:
                 label: i.label,
                 id: i.id,
                 required: i.required,
-                errorMessage: i.error_message
+                errorMessage: i.error_message,
+                validations: i.validations
               })
             }}
           </div>

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -293,5 +293,4 @@ function attachEventHandlers() {
 function init() {
   attachEventHandlers();
 }
-
-init();
+window.addEventListener('load', init, false);

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -289,8 +289,20 @@ function attachEventHandlers() {
     validateFyStartDate(e.target);
   });
 }
+function attachDatePickerHandlers() {
+  const dateInputsNeedingValidation = Array.from(
+    document.querySelectorAll('.usa-date-picker__wrapper input[type=text]')
+  );
+  dateInputsNeedingValidation.forEach((q) => {
+    q.addEventListener('blur', (e) => {
+      performValidations(e.target);
+    });
+  });
+}
 
 function init() {
   attachEventHandlers();
+  window.addEventListener('load', attachDatePickerHandlers, false); // Need to wait for date-picker text input to render.
 }
-window.addEventListener('load', init, false);
+
+init();

--- a/src/js/check-ueid.js
+++ b/src/js/check-ueid.js
@@ -225,6 +225,7 @@ function validateFyStartDate(fyInput) {
   const fyErrorContainer = document.getElementById('fy-error-message');
   const userFy = {};
   [userFy.year, userFy.month, userFy.day] = fyInput.value.split('-');
+  fyErrorContainer.innerHTML = '';
 
   if (userFy.year < 2020) {
     const errorEl = document.createElement('li');
@@ -237,7 +238,6 @@ function validateFyStartDate(fyInput) {
     fyErrorContainer.focus();
   } else {
     fyFormGroup.classList.remove('usa-form-group--error');
-    fyErrorContainer.innerHTML = '';
   }
 
   setFormDisabled(!allResponsesValid());


### PR DESCRIPTION
This PR adds the required form input indicators and functionality to the date-picker inputs. (https://github.com/GSA-TTS/FAC/issues/400)

[Preview link](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/jn-400-mark-dates-required/audit/new/step-2/)

## Walkthrough
### Added Required visual indicators (i.e. *)
![Screen Shot 2022-08-03 at 4 14 29 PM](https://user-images.githubusercontent.com/106776019/182721817-490267e2-970d-4dcd-98c7-dff5742e6c59.png)

### Error State: Blank input  
Once a user sets and removes focus from an empty input, the input is put into an error state.
![Screen Shot 2022-08-03 at 4 16 50 PM](https://user-images.githubusercontent.com/106776019/182722041-b950ab5d-23b0-4c1c-88da-7aa554816300.png)

### Fixed Error State: Blank input  
Once a user enters a valid date, the input is removed from the error state.
![Screen Shot 2022-08-08 at 12 46 07 PM](https://user-images.githubusercontent.com/106776019/183492234-5ef4cb42-c7a6-4b1a-9857-56651a2f967c.png)

