### PR TITLE
Make redirect to General Info form include `reportId` param

### DIFF
--- a/cypress/e2e/check-access-submit.cy.js
+++ b/cypress/e2e/check-access-submit.cy.js
@@ -103,17 +103,19 @@ describe('Create New Audit', () => {
     });
 
     it('should return SUCCESS response and move to the next page', () => {
+      const reportId = '2022UBT0001000020';
       cy.intercept('POST', '/sac/accessandsubmission', {
-        sac_id: 1,
+        report_id: reportId,
         next: 'TBD',
       }).as('validResponse');
 
       cy.get('.usa-button').contains('Create').click();
 
       cy.wait('@validResponse').then((interception) => {
-        expect(interception.response.body.sac_id).to.exist;
+        expect(interception.response.body.report_id).to.exist;
       });
       cy.url().should('include', 'submission');
+      cy.url().should('include', `reportId=${reportId}`);
     });
   });
 });

--- a/src/js/check-access.js
+++ b/src/js/check-access.js
@@ -33,9 +33,8 @@ function submitForm() {
 }
 
 function handleAccessResponse(data) {
-  console.log(data);
-  if (data.sac_id) {
-    const nextUrl = '../../submission';
+  if (data.report_id) {
+    const nextUrl = `../../submission/?reportId=${data.report_id}`;
     window.location.href = nextUrl;
   } else {
     console.log(data);


### PR DESCRIPTION
The SAC general info form needs a `reportId` query param in order to load data from the API when that page loads (and to know which object to `PUT` to on submitting that form). This PR implmements that functionality.

:eyes: [Federalist preview](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh/add-report-id-to-redirect-485/)

Addresses GSA-TTS/FAC#485