### PR TITLE
Implement award page

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -4,7 +4,8 @@
     "http://localhost:8080/audit/new/step-1",
     "http://localhost:8080/audit/new/step-2",
     "http://localhost:8080/audit/new/step-3",
-    "http://localhost:8080/audit/submission"
+    "http://localhost:8080/audit/submission",
+    "http://localhost:8080/audit/submission/awards/"
   ],
   "defaults": {
     "standard": "WCAG2AA",
@@ -12,6 +13,6 @@
       "htmlcs",
       "axe"
     ],
-    "hideElements": ".usa-select, .usa-step-indicator__segment-label, .is-hidden"
+    "hideElements": ".usa-select, .usa-step-indicator__segment-label, .is-hidden, #upload-worksheet, .usa-file-input__instructions"
   }
 }

--- a/assets/img/usa-icons/green-check.svg
+++ b/assets/img/usa-icons/green-check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path stroke="#00a91c" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>

--- a/cypress/e2e/run-lighthouse.cy.js
+++ b/cypress/e2e/run-lighthouse.cy.js
@@ -5,6 +5,7 @@ describe('Accessibility', () => {
     '/audit/new/step-2',
     '/audit/new/step-3',
     '/audit/submission',
+    '/audit/submission/awards',
     '/submissions',
   ];
   it('should get a perfect Lighthouse score for accessibility on every page', () => {

--- a/src/_includes/components/usa-file-input.njk
+++ b/src/_includes/components/usa-file-input.njk
@@ -1,0 +1,12 @@
+<div class="usa-form-group>
+  <span class="usa-error-message" id="{{ params.id }}-alert"></span>
+  <input
+    id={{ params.id }}
+    class="usa-file-input"
+    type="file"
+    name={{ params.id }}
+    {{ "accept="+params.accept if params.accept }}
+    aria-label={{ params.label }}
+    aria-description={{ params.hint }}
+  />
+</div>

--- a/src/_includes/components/usa-process-list.njk
+++ b/src/_includes/components/usa-process-list.njk
@@ -1,0 +1,9 @@
+<ol class="usa-process-list">
+  {% for step in params.steps %}
+    <li class="usa-process-list__item">
+      <h{{params.heading_level}} class="usa-process-list__heading">{{ step.heading }}</h{{ params.heading_level}}>
+      <p>{{ step.body }}</p>
+      {{ step.action | safe if step.action }}
+    </li>
+  {% endfor %}
+</ol>

--- a/src/_includes/form.njk
+++ b/src/_includes/form.njk
@@ -1,7 +1,9 @@
 {%- extends "layout.njk" -%}
   {%- block content -%}
-<div class="grid-container">
-    <h1>{{ title }}</h1>
-</div>
+    {%- if not hideHeader -%}
+      <div class="grid-container">
+        <h1>{{ title }}</h1>
+      </div>
+    {%- endif -%}
     {%- block form -%}{%- endblock -%}
   {%- endblock -%}

--- a/src/audit/submission/awards.njk
+++ b/src/audit/submission/awards.njk
@@ -66,6 +66,7 @@ sidenav:
             ]
           })
         }}
+        <button type="submit" class="usa-button">Save & continue to the next section</button>
     </form>
 </div>
 {%- endblock -%}

--- a/src/audit/submission/awards.njk
+++ b/src/audit/submission/awards.njk
@@ -24,7 +24,7 @@ sidenav:
 
 {%- extends "form.njk" -%}
 {%- block form -%}
-<div class="grid-container" x-data="$store">
+<div class="grid-container federal-awards" x-data="$store">
   <div class="grid-row grid-gap">
     <nav class="desktop:grid-col-3 sticky-nav" aria-label="Secondary navigation">
       {{

--- a/src/audit/submission/awards.njk
+++ b/src/audit/submission/awards.njk
@@ -1,0 +1,71 @@
+---
+title: Federal awards
+intro: Enter the federal awards you received in the last audit year using the provided worksheet
+
+sidenav:
+  links:
+    - text: General information
+      href: '#general-information'
+    - text: Federal awards
+      href: /
+      current: true
+    - text: Notes to SEFA
+      href: /
+    - text: Audit Information
+      href: /
+    - text: Findings text
+    - text: CAP text
+    - text: Additional EINs
+    - text: Additional UEIs
+    - text: Secondary auditors
+    - text: Finalize
+      href: /
+---
+
+{%- extends "form.njk" -%}
+{%- block form -%}
+<div class="grid-container" x-data="$store">
+  <div class="grid-row grid-gap">
+    <nav class="desktop:grid-col-3 sticky-nav" aria-label="Secondary navigation">
+      {{
+        component('usa-sidenav', {
+          links: sidenav.links,
+          baseUrl: config.baseUrl
+        }) 
+      }}
+    </nav>
+    <form class="desktop:grid-col-9 usa-form usa-form--large sf-sac" id="general-info">
+      <fieldset class="usa-fieldset">
+        <legend class="usa-legend usa-legend--large" id="general-information">{{ title }}</legend>
+        <p>
+          {{ intro }}
+        </p>
+        {{
+          component('usa-process-list', {
+            heading_level: 4,
+            steps: [
+              {
+                heading: "Download worksheet",
+                body: "The worksheet is an Excel spreadsheet file (XSLX file).",
+                action: '<button class="usa-button usa-button--outline" id="download-worksheet">Download worksheet</button>'
+              },
+              {
+                heading: "Complete worksheet",
+                body: "Open the worksheet using a program such as Microsoft Excel or Google Sheets and enter your federal awards in the worksheet"
+              },
+              {
+                heading: "Upload completed worksheet",
+                body: "Save your worksheet as an XSLX file and upload it below",
+                action: component('usa-file-input', {
+                  id: "upload-worksheet",
+                  accept: ".xslx",
+                  label: "Upload completed worksheet",
+                  hint: "Save your worksheet as an XSLX file and upload it below"
+                })
+              }
+            ]
+          })
+        }}
+    </form>
+</div>
+{%- endblock -%}

--- a/src/audit/submission/awards.njk
+++ b/src/audit/submission/awards.njk
@@ -22,6 +22,7 @@ sidenav:
       href: /
 ---
 
+{%- set hideHeader = true -%}
 {%- extends "form.njk" -%}
 {%- block form -%}
 <div class="grid-container federal-awards" x-data="$store">
@@ -36,13 +37,13 @@ sidenav:
     </nav>
     <form class="desktop:grid-col-9 usa-form usa-form--large sf-sac" id="general-info">
       <fieldset class="usa-fieldset">
-        <legend class="usa-legend usa-legend--large" id="general-information">{{ title }}</legend>
+        <legend class="usa-legend usa-legend--large" id="general-information"><h1>{{ title }}</h1></legend>
         <p>
           {{ intro }}
         </p>
         {{
           component('usa-process-list', {
-            heading_level: 4,
+            heading_level: 2,
             steps: [
               {
                 heading: "Download worksheet",

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -343,6 +343,13 @@ ul.usa-error-message {
 }
 
 .federal-awards {
+  margin-top: 2rem;
+
+  h1 {
+    font-size: size('body', 'xl');
+    margin: 0;
+  }
+
   .usa-button {
     margin-top: 0;
   }

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -351,4 +351,8 @@ ul.usa-error-message {
     border-color: #00a91c;
     content: url('../../assets/img/usa-icons/check.svg');
   }
+
+  [type="submit"] {
+    margin-top: 1rem;
+  }
 }

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -1,6 +1,5 @@
 @use 'uswds-core' as *;
 
-
 .usa-form {
   padding-bottom: 2rem;
 }
@@ -340,5 +339,16 @@ ul.usa-error-message {
         }
       }
     }
+  }
+}
+
+.federal-awards {
+  .usa-button {
+    margin-top: 0;
+  }
+
+  .usa-process-list__item.complete::before {
+    border-color: #00a91c;
+    content: url('../../assets/img/usa-icons/check.svg');
   }
 }

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -349,7 +349,7 @@ ul.usa-error-message {
 
   .usa-process-list__item.complete::before {
     border-color: #00a91c;
-    content: url('../../assets/img/usa-icons/check.svg');
+    content: url('../../assets/img/usa-icons/green-check.svg');
   }
 
   [type="submit"] {


### PR DESCRIPTION
This PR creates the Federal awards page (addressing GSA-TTS/FAC#462), which looks a little something like this:

<img width="827" alt="image" src="https://user-images.githubusercontent.com/6290/196765354-88e00b1b-f5b7-42fb-a5e8-445bc3e258de.png">

None of the buttons are functional, but those are covered in other issues (i.e. GSA-TTS/FAC#479). This PR also includes styles for a `.complete` class that can be added to the process list items in subsequent PRs when the page actually does stuff:

<img width="450" alt="image" src="https://user-images.githubusercontent.com/6290/196766512-b965270f-4fa0-4e17-85a0-077a63b16372.png">

:eyes: [Federalist Preview](https://federalist-9a617ff8-042d-4076-9581-bb999f9c6639.app.cloud.gov/preview/gsa-tts/fac-frontend/mh/create-award-page-462/audit/submission/awards) (requires auth)